### PR TITLE
nsq: disable output message buffering

### DIFF
--- a/nsq/consumer.go
+++ b/nsq/consumer.go
@@ -47,6 +47,8 @@ func NewConsumer(topic string, handler func(*Message) error,
 	cfg := gonsq.NewConfig()
 	cfg.MaxInFlight = o.maxInFlight
 	cfg.LookupdPollInterval = 10 * time.Second
+	cfg.OutputBufferSize = -1
+	cfg.OutputBufferTimeout = -1
 
 	c, err := gonsq.NewConsumer(topic, o.channel, cfg)
 	if err != nil {


### PR DESCRIPTION
By default, go-nsq buffers messages to 250ms.
https://github.com/minus5/services/blob/master/vendor/github.com/nsqio/go-nsq/config.go#L170

It does so to reduce the number of syscalls and improve throughput.
https://groups.google.com/forum/#!topic/nsq-users/eMrqtGwLYm4

In our case, by disabling buffering we have reduced the consumer message
handling times without any noticable strain on nsqd servers and/or consumer
services.