### PR TITLE
remove params not supported by mongo 4.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.idea
 example/tmp
 amp/sdk/js/node_modules/
 tmp

--- a/pkg/testu/mongo/mongo.go
+++ b/pkg/testu/mongo/mongo.go
@@ -66,9 +66,6 @@ func (dbs *Mongo) start() {
 		"--dbpath", dbs.DbPath,
 		"--bind_ip", "127.0.0.1",
 		"--port", strconv.Itoa(addr.Port),
-		"--nssize", "1",
-		"--noprealloc",
-		"--smallfiles",
 		"--nojournal",
 	}
 	dbs.server = exec.Command("mongod", args...)


### PR DESCRIPTION
https://docs.mongodb.com/manual/release-notes/4.2/#removed-mmapv1-storage-engine