### PR TITLE
add port for docscan

### DIFF
--- a/pkg/defaults/port.go
+++ b/pkg/defaults/port.go
@@ -67,15 +67,15 @@ const (
 	PortShareWs                   = "8581"
 	PortKladomatLogs              = "8590"
 	// Port 8600 is reserved by Consul as default dns forwarding port
-	PortPrematchSbk      = "8610"
-	PortPromo            = "8620"
-	PortWallet           = "8640" // definiram da se zna da je zauzet od strane casino walleta
-	PortNotification     = "8650"
-	PortPlayerAccount    = "8660"
-	PortPlayerAccountApi = "8670"
-	PortBetBuilder       = "8680"
-	PortWalletAdmin      = "8690"
-	PortVirtuals         = "8700"
-	PortCms              = "8710"
-	PortConsulAlerts     = "8720"
+	PortPrematchSbk   = "8610"
+	PortPromo         = "8620"
+	PortWallet        = "8640" // definiram da se zna da je zauzet od strane casino walleta
+	PortNotification  = "8650"
+	PortPlayerAccount = "8660"
+	PortDocscan       = "8670"
+	PortBetBuilder    = "8680"
+	PortWalletAdmin   = "8690"
+	PortVirtuals      = "8700"
+	PortCms           = "8710"
+	PortConsulAlerts  = "8720"
 )


### PR DESCRIPTION
Reused the port of player-account-api service that was never fully
developed and used.