### PR TITLE
add configurable options for RrConsumer

### DIFF
--- a/nsq/rr_consumer.go
+++ b/nsq/rr_consumer.go
@@ -92,8 +92,8 @@ func RequeueError(err error) func(*RrConsumer) {
 	}
 }
 
-// SetConsumerOptions sets configuration options for the underlying Consumer.
-func SetConsumerOptions(opts ...func(*options)) func(*RrConsumer) {
+// ConsumerOptions sets configuration options for the underlying Consumer.
+func ConsumerOptions(opts ...func(*options)) func(*RrConsumer) {
 	return func(s *RrConsumer) {
 		s.consumerOptions = opts
 	}

--- a/nsq/rr_consumer.go
+++ b/nsq/rr_consumer.go
@@ -20,10 +20,11 @@ var (
 // RrConsumer request reponse consumer.
 // Implements consumer side of the request response communication over nsq.
 type RrConsumer struct {
-	topic        string
-	sub          *Consumer
-	producers    map[string]*Producer
-	requeueError error // set this error to requeue only on this
+	topic           string
+	sub             *Consumer
+	producers       map[string]*Producer
+	consumerOptions []func(*options)
+	requeueError    error // set this error to requeue only on this
 	// if nil requeues on all errors
 	sync.Mutex
 }
@@ -73,7 +74,8 @@ func RrSub(topic string, handler func(string, []byte) (interface{}, error), opts
 		}
 		return nil
 	}
-	s.sub = Sub(topic, h, Channel(env.AppName()))
+	s.consumerOptions = append(s.consumerOptions, Channel(env.AppName()))
+	s.sub = Sub(topic, h, s.consumerOptions...)
 	return s
 }
 
@@ -87,6 +89,13 @@ func (s *RrConsumer) apply(opts ...func(*RrConsumer)) {
 func RequeueError(err error) func(*RrConsumer) {
 	return func(s *RrConsumer) {
 		s.requeueError = err
+	}
+}
+
+// SetConsumerOptions sets configuration options for the underlying Consumer.
+func SetConsumerOptions(opts ...func(*options)) func(*RrConsumer) {
+	return func(s *RrConsumer) {
+		s.consumerOptions = opts
 	}
 }
 


### PR DESCRIPTION
SetConsumerOptions function can be used to set configuration options of RrConsumer's underlying Consumer (e.g. MaxInFlight, Concurrency etc.).

This solves a case when application has multiple consumers that need to be configured differently. If one of those consumers was RrConsumer, there were no means to configure it besides setting a global nsq configuration which would be applied to all other consumers as well.
The usage is simple - when creating a new RrConsumer, add SetConsumerOptions as one of the options:
`consumer := nsq.RrSub("topic.name", handler, nsq.SetConsumerOptions(nsq.MaxInFlight(128), nsq.Concurrency(16)))`


