### PR TITLE
add default ports for community_api service

### DIFF
--- a/pkg/defaults/port.go
+++ b/pkg/defaults/port.go
@@ -103,4 +103,7 @@ const (
 	PortPGWPaysafe       = "8940"
 	PortPGWKeksPay       = "8950"
 	PortLoyalty          = "8960"
+	PortCommunityApi     = "8970"
+	PortCommunityApiWs   = "8971"
+	PortCommunityApiRest = "8972"
 )


### PR DESCRIPTION
Add ports for community_api service to avoid port clashing in devenv