### PR TITLE
EnableDebug function added

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -93,6 +93,11 @@ func DisableDebug() {
 	debugLogLevelEnabled = false
 }
 
+// EnableDebug do log Debug messages
+func EnableDebug() {
+	debugLogLevelEnabled = true
+}
+
 func setSyslogOutput(addr string) {
 	sys, err := syslog.Dial("udp", addr, syslog.LOG_LOCAL5, env.AppName())
 	if err != nil {


### PR DESCRIPTION
Currently there is a function **DisableDebug** that can be used to disable debug logging on the fly (i.e. without restarting the application).

What is missing is **EnableDebug** function that would enable log messages. We need this kind of function in risk management system to enable detailed logs on the fly for troubleshooting and then to disable debug again to prevent too many logs being created. Both of this actions should happen on the fly (by calling dedicated management endpoint of the application).