### PR TITLE
Enable request topic whitelisting for amp sessions

### DIFF
--- a/amp/session/session_test.go
+++ b/amp/session/session_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/minus5/svckit/amp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type mockConn struct {
@@ -46,11 +47,26 @@ func (b *mockBroker) Subscribe(amp.Sender, map[string]int64) {}
 func (b *mockBroker) Unsubscribe(amp.Sender)                 {}
 func (b *mockBroker) Wait()                                  {}
 
-type mockRequester struct{}
+type mockRequester struct {
+	t *testing.T
 
-func (r *mockRequester) Send(amp.Subscriber, *amp.Msg) {}
-func (r *mockRequester) Unsubscribe(amp.Subscriber)    {}
-func (r *mockRequester) Wait()                         {}
+	WantSendCalls int
+	gotSendCalls  int
+}
+
+func (r *mockRequester) Send(subscriber amp.Subscriber, msg *amp.Msg) {
+	r.gotSendCalls++
+
+	require.True(r.t, r.WantSendCalls >= r.gotSendCalls)
+}
+
+func (r *mockRequester) Unsubscribe(amp.Subscriber) {}
+
+func (r *mockRequester) Wait() {}
+
+func (r *mockRequester) Assert(t *testing.T) {
+	require.Equal(t, r.WantSendCalls, r.gotSendCalls)
+}
 
 func testSession(outLen, inLen int) (chan []byte, chan []byte, func(), chan struct{}, func(*amp.Msg)) {
 	out := make(chan []byte, outLen)
@@ -152,4 +168,61 @@ func TestQueueDrain(t *testing.T) {
 	cancel()
 	<-done
 	assert.Len(t, s.outMessages, 0)
+}
+
+func Test_session_receive(t *testing.T) {
+	type fields struct {
+		conn           mockConn
+		requester      mockRequester
+		topicWhitelist []string
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		in     *amp.Msg
+	}{
+		{
+			name: "it should call Send on requester if msg topic is whitelisted",
+			fields: fields{
+				requester: mockRequester{
+					t:             t,
+					WantSendCalls: 1,
+				},
+				topicWhitelist: []string{"whitelisted.req"},
+			},
+			in: &amp.Msg{
+				Type: amp.Request,
+				URI:  "whitelisted.req/method",
+			},
+		},
+		{
+			name: "it should not call Send on requester if msg topic is not whitelisted",
+			fields: fields{
+				requester: mockRequester{
+					t:             t,
+					WantSendCalls: 0,
+				},
+				topicWhitelist: []string{"whitelisted.req"},
+			},
+			in: &amp.Msg{
+				Type: amp.Request,
+				URI:  "blacklisted.req/method",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &session{
+				conn:           &tt.fields.conn,
+				requester:      &tt.fields.requester,
+				topicWhitelist: tt.fields.topicWhitelist,
+			}
+
+			s.receive(tt.in)
+
+			tt.fields.requester.Assert(t)
+		})
+	}
 }

--- a/cmd/amp_tester/main.go
+++ b/cmd/amp_tester/main.go
@@ -40,7 +40,7 @@ func main() {
 	requester := nsq.MustRequester(interupt)
 	broker := broker.New(requester.Current, nil)
 	broker.Consume(nsq.Subscribe(interupt, inputTopics))
-	sessions := session.Factory(interupt, broker, requester)
+	sessions := session.Factory(interupt, broker, requester, inputTopics)
 	defer sessions.Wait()
 
 	go debugHTTP()

--- a/example/amp/main.go
+++ b/example/amp/main.go
@@ -37,7 +37,7 @@ func main() {
 	requester := nsq.MustRequester(interupt)
 	broker := broker.New(requester.Current, nil)
 	broker.Consume(nsq.Subscribe(interupt, inputTopics))
-	sessions := session.Factory(interupt, broker, requester)
+	sessions := session.Factory(interupt, broker, requester, inputTopics)
 	defer sessions.Wait()
 
 	go debugHTTP()


### PR DESCRIPTION
## Enable request topic whitelisting for amp sessions

The current amp sessions handler implementation allows clients to arbitrarily select on which NSQ topic to send a request. This is good from implementation perspective, as adding new request topics is easy, but is bad from security perspective, as it can be exploited by malicious clients.

The `sessions.Factory` constructor now accepts a list of whitelisted topics. Client requests will be forwarded only if requested topic is in this list. Otherwise, nothing will happen - there will be no error response sent back to the client, the request will be discarded silently.

This is a breaking change, as the signature of constructor function has been changed. 
