### PR TITLE
add backward compatible serde for mongo cache

### DIFF
--- a/pkg/mdb2/mdb.go
+++ b/pkg/mdb2/mdb.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"go.mongodb.org/mongo-driver/x/mongo/driver"
 	"reflect"
 	"strings"
 	"text/template"
@@ -219,7 +220,7 @@ func (mdb *Mdb) Init(connStr string, opts ...func(db *Mdb)) error {
 	}
 
 	if mdb.cacheDir != "" {
-		mdb.cache, err = newCache(mdb)
+		mdb.cache, err = newCache(mdb, reg)
 		if err != nil {
 			return err
 		}
@@ -547,4 +548,15 @@ func IsDup(err error) bool {
 		}
 	}
 	return false
+}
+
+// IsUnackWrite checks if error is unacknowledged write error
+func IsUnackWrite(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return errors.Is(err, mongo.ErrUnacknowledgedWrite) ||
+		errors.Is(err, driver.ErrUnacknowledgedWrite) ||
+		err.Error() == mongo.ErrUnacknowledgedWrite.Error()
 }


### PR DESCRIPTION
Add check to ingore unacknowledge write on cache purge (necessary when opening connection with writeConcer: 0.
Add deserialization mechanics to cache same as for the data coming from mongodb.

Issues requiring these fixes are described here: https://3.basecamp.com/3077084/buckets/10103289/messages/5732789325%5C\#__recording_5864997976