### PR TITLE
amp - use all unprocessed headers when creating web socket connection

### DIFF
--- a/amp/ws/listener.go
+++ b/amp/ws/listener.go
@@ -142,7 +142,7 @@ func (l *listener) upgrade(tc net.Conn) (connCap, error) {
 			case "cookie":
 				cc.cookie = value
 			default:
-				log.S("key", key).S("value", value).Debug("header")
+				cc.headers[key] = value
 			}
 			return nil
 		},


### PR DESCRIPTION
The change is pretty simple - instead of just logging headers that were unprocessed by `OnHeader` function, just set that headers in connCap headers field.

Currently, amp package does not use these headers in any way, so nothing should break. It allows package consumers to retrieve these headers using the provided `Conn#Headers` method.
