### PR TITLE
AMP - add backend exclusive headers

### DIFF
--- a/amp/nsq/publisher.go
+++ b/amp/nsq/publisher.go
@@ -8,7 +8,7 @@ import (
 func Publish(topic string, in <-chan *amp.Msg) chan *amp.Msg {
 	pub := nsq.Pub(topic)
 	publish := func(m *amp.Msg) {
-		pub.Publish(m.Marshal())
+		pub.Publish(m.MarshalForBackend())
 	}
 	out := make(chan *amp.Msg, 16)
 	go func() {
@@ -34,7 +34,7 @@ func (p *Publisher) loop(in <-chan *amp.Msg) {
 
 	pub := nsq.Pub("")
 	publish := func(m *amp.Msg) {
-		pub.PublishTo(m.Topic(), m.Marshal())
+		pub.PublishTo(m.Topic(), m.MarshalForBackend())
 	}
 
 	for m := range in {

--- a/amp/nsq/requester.go
+++ b/amp/nsq/requester.go
@@ -60,7 +60,7 @@ func resposesTopicName() string {
 }
 
 func (r *Requester) responses(nm *nsq.Message) error {
-	m := amp.Parse(nm.Body)
+	m := amp.ParseFromBackend(nm.Body)
 	r.reply(m.CorrelationID, m)
 	return nil
 }
@@ -91,7 +91,7 @@ func (r *Requester) Send(e amp.Subscriber, m *amp.Msg) {
 	rm := m.Request()
 	rm.CorrelationID = correlationID
 	rm.ReplyTo = r.topic
-	buf := rm.Marshal()
+	buf := rm.MarshalForBackend()
 
 	go func() {
 		err := r.producer.PublishTo(m.Topic(), buf)

--- a/amp/nsq/responder.go
+++ b/amp/nsq/responder.go
@@ -41,7 +41,7 @@ func (r *Responder) loop(in <-chan *amp.Msg) {
 		if rm == nil || m.ReplyTo == "" {
 			continue
 		}
-		if err := pub.PublishTo(m.ReplyTo, rm.Marshal()); err != nil {
+		if err := pub.PublishTo(m.ReplyTo, rm.MarshalForBackend()); err != nil {
 			log.Error(err)
 		}
 	}

--- a/amp/nsq/subscriber.go
+++ b/amp/nsq/subscriber.go
@@ -19,7 +19,7 @@ type subscriber struct {
 func (s *subscriber) onMessage(m *nsq.Message) error {
 	s.msgs.Add(1)
 	defer s.msgs.Done()
-	am := amp.Parse(m.Body)
+	am := amp.ParseFromBackend(m.Body)
 	if am == nil {
 		return nil
 	}

--- a/amp/session/factory.go
+++ b/amp/session/factory.go
@@ -22,14 +22,16 @@ type broker interface {
 }
 
 type connection interface {
-	Read() ([]byte, error)                     // get client message
-	Write(payload []byte, deflated bool) error // send message to the client
-	DeflateSupported() bool                    // does websocket connection support per message deflate
-	Headers() map[string]string                // http headers we got on connection open
-	No() uint64                                // connection identifier (for grouping logs)
-	Close() error                              // close connection
-	Meta() map[string]string                   // session metadata, set by the client
-	SetMeta(map[string]string)                 // set session metadata
+	Read() ([]byte, error)                       // get client message
+	Write(payload []byte, deflated bool) error   // send message to the client
+	DeflateSupported() bool                      // does websocket connection support per message deflate
+	Headers() map[string]string                  // http headers we got on connection open
+	SetBackendHeaders(headers map[string]string) // set BackendHeaders
+	GetBackendHeaders() map[string]string        // get BackendHeaders
+	No() uint64                                  // connection identifier (for grouping logs)
+	Close() error                                // close connection
+	Meta() map[string]string                     // session metadata, set by the client
+	SetMeta(map[string]string)                   // set session metadata
 	GetRemoteIp() string
 	GetCookie() string
 }

--- a/amp/session/session.go
+++ b/amp/session/session.go
@@ -150,6 +150,7 @@ func (s *session) receive(m *amp.Msg) {
 			return
 		}
 		m.Meta = s.conn.Meta()
+		m.BackendHeaders = s.conn.GetBackendHeaders()
 		s.requester.Send(s, m)
 	case amp.Subscribe:
 		s.broker.Subscribe(s, m.Subscriptions)

--- a/amp/v1_compatibility.go
+++ b/amp/v1_compatibility.go
@@ -73,13 +73,13 @@ func ParseV1Subscriptions(buf []byte) *Msg {
 
 // Marshal packs message for sending on the wire
 func (m *Msg) MarshalV1() []byte {
-	buf, _ := m.marshal(CompressionNone, CompatibilityVersion1)
+	buf, _ := m.marshal(CompressionNone, CompatibilityVersion1, jsonSerializer)
 	return buf
 }
 
 // MarshalDeflate packs and compress message
 func (m *Msg) MarshalV1Deflate() ([]byte, bool) {
-	return m.marshal(CompressionDeflate, CompatibilityVersion1)
+	return m.marshal(CompressionDeflate, CompatibilityVersion1, jsonSerializer)
 }
 
 func (m *Msg) marshalV1header() []byte {

--- a/amp/ws/conn.go
+++ b/amp/ws/conn.go
@@ -18,8 +18,9 @@ type Conn struct {
 	tcpConn net.Conn
 	cap     connCap
 	no      uint64
-	//	receive    chan []byte
-	//	receiveErr error
+
+	// backendHeaders can only be set and read on the backend.
+	backendHeaders map[string]string
 }
 
 // connCap connection capabilities and usefull atributes
@@ -52,7 +53,6 @@ func newConn(tc net.Conn, cap connCap) *Conn {
 		tcpConn: tc,
 		cap:     cap,
 		no:      no(),
-		// receive: make(chan []byte),
 	}
 	return c
 }
@@ -60,6 +60,20 @@ func newConn(tc net.Conn, cap connCap) *Conn {
 // Headers usefull http headers
 func (c *Conn) Headers() map[string]string {
 	return c.cap.headers
+}
+
+func (c *Conn) SetBackendHeaders(headers map[string]string) {
+	if c.backendHeaders == nil {
+		c.backendHeaders = make(map[string]string)
+	}
+
+	for k, v := range headers {
+		c.backendHeaders[k] = v
+	}
+}
+
+func (c *Conn) GetBackendHeaders() map[string]string {
+	return c.backendHeaders
 }
 
 // Write writes payload to the websocket connection.

--- a/go.mod
+++ b/go.mod
@@ -44,11 +44,14 @@ require (
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/serf v0.10.1 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.13.6 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe // indirect
 	github.com/onsi/ginkgo v1.11.0 // indirect
 	github.com/onsi/gomega v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -116,6 +116,8 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
+github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/klauspost/compress v1.13.6 h1:P76CopJELS0TiO2mebmnzgWaajssP/EszplttgQxcgc=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
@@ -163,9 +165,12 @@ github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
+github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe h1:iruDEfMl2E6fbMZ9s0scYfZQ84/6SPL6zC8ACM2oIL0=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=


### PR DESCRIPTION
The headers are set on WS connection level, much like Meta fields, but can only be set and read on the backend.

The headers are added to any Request type message received from client, and are stripped from it's corresponding Response.