### PR TITLE
Adopt go-nsqx library for wrapper in svckit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/minus5/svckit
 
-go 1.25.0
+go 1.26
 
 require (
 	github.com/aws/aws-sdk-go v1.55.7
@@ -16,9 +16,9 @@ require (
 	github.com/hashicorp/consul/api v1.18.0
 	github.com/json-iterator/go v1.1.12
 	github.com/koding/websocketproxy v0.0.0-20181220232114-7ed82d81a28c
+	github.com/minus5/go-nsqx v1.0.0
 	github.com/minus5/go-simplejson v0.5.1-0.20190518182223-8af509724a86
 	github.com/nranchev/go-libGeoIP v0.0.0-20170629073846-d6d4a9a4c7e8
-	github.com/nsqio/go-nsq v1.1.0
 	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d
 	github.com/oschwald/geoip2-golang v1.7.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -51,7 +51,6 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c h1:964Od4U6p2jUkFxvCydnIczKteheJEzHRToSGK3Bnlw=
@@ -154,6 +153,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41 h1:WMszZWJG0XmzbK9FEmzH2TVcqYzFesusSIB41b8KHxY=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=
+github.com/minus5/go-nsqx v1.0.0 h1:mP4xLDKmjHP6GX5HiPjEqlspJu7dRaDem5euzvApy6Q=
+github.com/minus5/go-nsqx v1.0.0/go.mod h1:U0qLktCviUuRBuVAbKq/Oq7EQmObdp4g2CWrizN5fMo=
 github.com/minus5/go-simplejson v0.5.1-0.20190518182223-8af509724a86 h1:bsm6+lQ2ea4dD6ZzGCz6GHXxmfU0ludQ4Cjxm7h/D9o=
 github.com/minus5/go-simplejson v0.5.1-0.20190518182223-8af509724a86/go.mod h1:eBPLk8FJ9uc035DnbHAWvINeYXIIVduZe5EILao6s7o=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
@@ -177,8 +178,6 @@ github.com/montanaflynn/stats v0.7.1/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nranchev/go-libGeoIP v0.0.0-20170629073846-d6d4a9a4c7e8 h1:IeI4GVfCGrGx4tZROZ/ju+nO9rKpgKJ7o4XmQgAM/2g=
 github.com/nranchev/go-libGeoIP v0.0.0-20170629073846-d6d4a9a4c7e8/go.mod h1:CSS25pAr1pT+qxFdpFZIJFHraF4zZfZYeFirlVvLXb4=
-github.com/nsqio/go-nsq v1.1.0 h1:PQg+xxiUjA7V+TLdXw7nVrJ5Jbl3sN86EhGCQj4+FYE=
-github.com/nsqio/go-nsq v1.1.0/go.mod h1:vKq36oyeVXgsS5Q8YEO7WghqidAVXQlcFxzQbQTuDEY=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d h1:VhgPp6v9qf9Agr/56bj7Y/xa04UccTW04VP0Qed4vnQ=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d/go.mod h1:YUTz3bUH2ZwIWBy3CJBeOBEugqcmXREj14T+iG/4k4U=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/nsq/consumer.go
+++ b/nsq/consumer.go
@@ -2,16 +2,15 @@ package nsq
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/minus5/svckit/dcy"
 	"github.com/minus5/svckit/log"
 
-	gonsq "github.com/nsqio/go-nsq"
+	nsqx "github.com/minus5/go-nsqx"
 )
 
 type Consumer struct {
-	nsqConsumer *gonsq.Consumer
+	nsqConsumer *nsqx.Consumer
 	logger      func() *log.Agregator
 	lookups     dcy.Addresses
 }
@@ -20,7 +19,7 @@ type nsqHandler struct {
 	fn func(*Message) error
 }
 
-func (h *nsqHandler) HandleMessage(m *gonsq.Message) error {
+func (h *nsqHandler) HandleMessage(m *nsqx.Message) error {
 	// javi periodicki nsqd-u da je procesiranje jos u tijeku
 	stop := every(DefaultMsgTouchInterval, m.Touch)
 	defer close(stop)
@@ -44,19 +43,19 @@ func NewConsumer(topic string, handler func(*Message) error,
 	o := getDefaults().clone()
 	o.apply(opts...)
 
-	cfg := gonsq.NewConfig()
-	cfg.MaxInFlight = o.maxInFlight
-	cfg.LookupdPollInterval = 10 * time.Second
-	cfg.OutputBufferSize = -1
-	cfg.OutputBufferTimeout = -1
+	cfg := o.toNsqxConfig()
 
-	c, err := gonsq.NewConsumer(topic, o.channel, cfg)
+	c, err := nsqx.NewConsumer(topic, o.channel, cfg)
 	if err != nil {
 		return nil, err
 	}
 
 	c.SetLogger(o.logger, o.logLevel)
-	c.AddConcurrentHandlers(&nsqHandler{fn: handler}, o.concurrency)
+	c.AddConcurrentHandlers(&nsqHandler{fn: handler}, o.Concurrency())
+
+	// Use shared Discovery so all consumers in the process share one lookupd poller
+	disc := getDiscovery(o)
+	c.SetDiscovery(disc)
 
 	err = c.ConnectToNSQLookupds(o.lookupds.String())
 	if err != nil {
@@ -71,41 +70,50 @@ func NewConsumer(topic string, handler func(*Message) error,
 		},
 	}
 
-	co.logger().I("maxInFlight", o.maxInFlight).I("concurrency", o.concurrency).Debug("starting consumer")
+	co.logger().I("maxInFlight", o.maxInFlight).I("concurrency", o.Concurrency()).Debug("starting consumer")
 	dcy.Subscribe(LookupdHTTPServiceName, co.onLookupChanges)
 	dcy.SubscribeByTag(LookupdHTTPServiceNameByTag, LookupdHTTPServiceTag, co.onLookupChanges)
 	return co, nil
 }
 
 func (c *Consumer) onLookupChanges(as dcy.Addresses) {
+	// dcy.Addresses lookupd returns all lookupds from Consul, based on service name
+	// and service tags (eg. nsqlookupd-tcp and tcp.nsqlookupd will return same IP twice)
+	// -> this should maybe be added to dcy pkg
+	seen := make(map[string]struct{})
+	var unique []string
 	for _, a := range as {
-		if err := c.nsqConsumer.ConnectToNSQLookupd(a.String()); err != nil {
-			logger().Error(err)
+		s := a.String()
+		if _, dup := seen[s]; !dup {
+			seen[s] = struct{}{}
+			unique = append(unique, s)
 		}
 	}
-	for _, a := range c.lookups {
-		if !as.Contains(a) {
-			if err := c.nsqConsumer.DisconnectFromNSQLookupd(a.String()); err != nil {
-				logger().Error(err)
-			}
-		}
-	}
+
+	// Update shared Discovery address list, it will use
+	// these new addresses on the next cache miss/poll cycle
+	disc := getDiscovery(getDefaults())
+	disc.SetAddrs(unique)
 	c.lookups = as
-	c.logger().S("lookupds", fmt.Sprintf("%v", as)).Debug("lookupds update")
+	c.logger().S("lookupds", fmt.Sprintf("%v", unique)).Info("lookupds update") // if too much logs, set Debug
 }
 
 func (c *Consumer) Close() {
 	dcy.Unsubscribe(LookupdHTTPServiceName, c.onLookupChanges)
 	dcy.UnsubscribeByTag(LookupdHTTPServiceNameByTag, LookupdHTTPServiceTag, c.onLookupChanges)
 	c.nsqConsumer.Stop()
-	<-c.nsqConsumer.StopChan
 }
 
-// StartClosing will initiate a graceful stop of the Consumer (permanent)
-// Receive on returned chan to block until this process completes
+// StartClosing will initiate a graceful stop of the Consumer (permanent),
+// receive on returned chan to block until this process completes
 func (c *Consumer) StartClosing() chan int {
 	dcy.Unsubscribe(LookupdHTTPServiceName, c.onLookupChanges)
 	dcy.UnsubscribeByTag(LookupdHTTPServiceNameByTag, LookupdHTTPServiceTag, c.onLookupChanges)
 	c.nsqConsumer.Stop()
-	return c.nsqConsumer.StopChan
+	// go-nsqx Stop() is synchronous, it blocks until fully stopped,
+	// return a closed channel to maintain the same API shape
+	// TODO - Maybe change this later?
+	ch := make(chan int)
+	close(ch)
+	return ch
 }

--- a/nsq/message.go
+++ b/nsq/message.go
@@ -3,25 +3,25 @@ package nsq
 import (
 	"time"
 
-	gonsq "github.com/nsqio/go-nsq"
+	nsqx "github.com/minus5/go-nsqx"
 )
 
-// Presipavam da klijent ne bi morao referencirati go-nsq package.
+// Presipavam da klijent ne bi morao referencirati go-nsqx package.
 type Message struct {
-	nsqm        *gonsq.Message
-	ID          gonsq.MessageID
+	nsqm        *nsqx.Message
+	ID          nsqx.MessageID
 	Body        []byte
-	Timestamp   int64
+	Timestamp   int64 // unix nanoseconds — preserved from original API
 	Attempts    uint16
 	NSQDAddress string
 }
 
-func newMessage(m *gonsq.Message) *Message {
+func newMessage(m *nsqx.Message) *Message {
 	return &Message{
 		nsqm:        m,
 		ID:          m.ID,
 		Body:        m.Body,
-		Timestamp:   m.Timestamp,
+		Timestamp:   m.Timestamp.UnixNano(),
 		Attempts:    m.Attempts,
 		NSQDAddress: m.NSQDAddress,
 	}

--- a/nsq/nsq.go
+++ b/nsq/nsq.go
@@ -14,7 +14,7 @@ import (
 	"github.com/minus5/svckit/log"
 	"github.com/minus5/svckit/signal"
 
-	gonsq "github.com/nsqio/go-nsq"
+	nsqx "github.com/minus5/go-nsqx"
 )
 
 const (
@@ -25,7 +25,6 @@ const (
 	LookupdHTTPServiceTag       = "http"
 	EnvNsqd                     = "SVCKIT_NSQD"
 	DefaultMsgTouchInterval     = time.Second * 30
-	//NsqdTCPServiceName      = "nsqd-tcp"
 )
 
 var (
@@ -33,8 +32,9 @@ var (
 	Pub = MustNewProducer
 	Sub = MustNewConsumer
 
-	defaults *options
-	initMu   sync.Mutex
+	defaults  *options
+	initMu    sync.Mutex
+	discovery *nsqx.Discovery // shared across all consumers
 )
 
 func getDefaults() *options {
@@ -62,7 +62,7 @@ func initDefaults() {
 		channel:     fmt.Sprintf("%s-%s", env.AppName(), env.InstanceId()),
 		nsqdTCPAddr: "127.0.0.1:4150",
 		lookupds:    dcy.Addresses{dcy.Address{Address: "127.0.0.1", Port: 4161}},
-		logLevel:    gonsq.LogLevelWarning,
+		logLevel:    nsqx.LogLevelWarning,
 		logger:      &nsqLogger{},
 	}
 	if e, ok := os.LookupEnv(EnvNsqd); ok && e != "" {
@@ -95,6 +95,17 @@ func initDefaults() {
 	if err := signal.WithExponentialBackoff(connect); err != nil {
 		logger().Fatal(err)
 	}
+}
+
+// getDiscovery returns the shared Discovery instance
+func getDiscovery(o *options) *nsqx.Discovery {
+	initMu.Lock()
+	defer initMu.Unlock()
+	if discovery == nil {
+		cfg := o.toNsqxConfig()
+		discovery = nsqx.NewDiscovery(o.lookupds.String(), cfg, o.logger)
+	}
+	return discovery
 }
 
 func logger() *log.Agregator {

--- a/nsq/options.go
+++ b/nsq/options.go
@@ -11,24 +11,23 @@ Primjer:
 package nsq
 
 import (
+	"crypto/tls"
 	"strings"
+	"time"
 
 	"github.com/minus5/svckit/dcy"
 	"github.com/minus5/svckit/log"
 
-	gonsq "github.com/nsqio/go-nsq"
+	nsqx "github.com/minus5/go-nsqx"
 )
 
-type nsqLogger struct {
-}
+type nsqLogger struct{}
 
-// Ovdje ulaze logovi iz go-nsq liba.
-// Da ne idu na stderr postavim SetLogger na producer i consumer.
-// Pa onda mogu nesto korisni napraviti s njima.
-// Ref: https://github.com/nsqio/go-nsq/blob/0b80d6f05e15ca1930e0c5e1d540ed627e299980/delegates.go#L6
+// Ovdje ulaze logovi iz go-nsqx liba,
+// Logger interface is Output(calldepth int, s string) error — identical in go-nsq and go-nsqx
 func (n *nsqLogger) Output(calldepth int, s string) error {
 	a := log.NewAgregator(nil, calldepth)
-	a.S("lib", "svckit.nsq.gonsq")
+	a.S("lib", "svckit.nsq.gonsqx")
 	if strings.HasPrefix(s, "INF") {
 		a.Info(s)
 		return nil
@@ -50,13 +49,84 @@ func (n *nsqLogger) Output(calldepth int, s string) error {
 }
 
 type options struct {
+	// Existing options
 	maxInFlight int
 	concurrency int
 	channel     string
 	nsqdTCPAddr string
 	logger      *nsqLogger
-	logLevel    gonsq.LogLevel
+	logLevel    nsqx.LogLevel
 	lookupds    dcy.Addresses
+
+	// Timeouts
+	dialTimeout  time.Duration
+	readTimeout  time.Duration
+	writeTimeout time.Duration
+
+	// Discovery
+	lookupdPollInterval time.Duration
+	lookupdPollJitter   float64
+	lookupdCacheTTL     time.Duration
+	lookupdPollTimeout  time.Duration
+
+	// Adaptive RDY
+	rdyEvalInterval      time.Duration
+	rdySlowStartInitial  int64
+	rdySlowStartInterval time.Duration
+	idleConnectionRDY    int64
+	emaAlpha             float64
+	idleRateThreshold    float64
+	idleTicksRequired    int
+
+	// Retry & backoff
+	maxAttempts             uint16
+	backoffAlgorithm        nsqx.BackoffAlgo
+	backoffBaseDelay        time.Duration
+	backoffMaxDelay         time.Duration
+	backoffMaxExponent      uint
+	backoffFixedInterval    time.Duration
+	backoffFixedMaxAttempts int
+
+	// Circuit breaker
+	circuitBreakerThreshold  int32
+	circuitBreakerResetAfter time.Duration
+
+	// Producer
+	producerPipelines int
+	batchMaxSize      int
+	batchMaxDelay     time.Duration
+
+	// Server side buffering
+	heartbeatInterval   time.Duration
+	outputBufferSize    int
+	outputBufferTimeout time.Duration
+
+	// Compression
+	compression  nsqx.CompressionCodec
+	deflateLevel int
+
+	// Zero copy / ACK batching / adaptive buffer
+	zeroCopyThreshold     int
+	ackBatchSize          int
+	ackBatchDelay         time.Duration
+	adaptiveBufferEnabled *bool // pointer to detect "not set"
+	adaptiveBufferInitial int
+	adaptiveBufferMax     int
+
+	// Identity
+	clientID  string
+	hostname  string
+	userAgent string
+
+	// Metrics
+	metricsBackend       nsqx.MetricsBackend
+	statsdAddr           string
+	statsdPrefix         string
+	prometheusNamespace  string
+	metricsFlushInterval time.Duration
+
+	// TLS
+	tlsConfig *tls.Config
 }
 
 func (o *options) clone() *options {
@@ -69,50 +139,376 @@ func (o *options) set(opts ...func(*options)) {
 	o.apply(opts...)
 }
 
-func (c *options) apply(opts ...func(*options)) *options {
+func (o *options) apply(opts ...func(*options)) *options {
 	for _, fn := range opts {
-		fn(c)
+		fn(o)
 	}
-	return c
+	return o
 }
 
-func (c *options) Concurrency() int {
-	if c.concurrency != 0 {
-		return c.concurrency
+func (o *options) Concurrency() int {
+	if o.concurrency != 0 {
+		return o.concurrency
 	}
-	return c.maxInFlight
+	return o.maxInFlight
 }
+
+// toNsqxConfig builds a go-nsqx Config from the wrapper options,
+// applying only non zero overrides on top of go-nsqx defaults
+func (o *options) toNsqxConfig() *nsqx.Config {
+	cfg := nsqx.NewConfig()
+	cfg.MaxInFlight = o.maxInFlight
+	cfg.WorkerConcurrency = o.Concurrency()
+	cfg.LogLevel = o.logLevel
+
+	// Timeouts
+	if o.dialTimeout > 0 {
+		cfg.DialTimeout = o.dialTimeout
+	}
+	if o.readTimeout > 0 {
+		cfg.ReadTimeout = o.readTimeout
+	}
+	if o.writeTimeout > 0 {
+		cfg.WriteTimeout = o.writeTimeout
+	}
+
+	// Discovery
+	if o.lookupdPollInterval > 0 {
+		cfg.LookupdPollInterval = o.lookupdPollInterval
+	}
+	if o.lookupdPollJitter > 0 {
+		cfg.LookupdPollJitter = o.lookupdPollJitter
+	}
+	if o.lookupdCacheTTL > 0 {
+		cfg.LookupdCacheTTL = o.lookupdCacheTTL
+	}
+	if o.lookupdPollTimeout > 0 {
+		cfg.LookupdPollTimeout = o.lookupdPollTimeout
+	}
+
+	// Adaptive RDY
+	if o.rdyEvalInterval > 0 {
+		cfg.RDYEvalInterval = o.rdyEvalInterval
+	}
+	if o.rdySlowStartInitial > 0 {
+		cfg.RDYSlowStartInitial = o.rdySlowStartInitial
+	}
+	if o.rdySlowStartInterval > 0 {
+		cfg.RDYSlowStartInterval = o.rdySlowStartInterval
+	}
+	if o.idleConnectionRDY > 0 {
+		cfg.IdleConnectionRDY = o.idleConnectionRDY
+	}
+	if o.emaAlpha > 0 {
+		cfg.EMAAlpha = o.emaAlpha
+	}
+	if o.idleRateThreshold > 0 {
+		cfg.IdleRateThreshold = o.idleRateThreshold
+	}
+	if o.idleTicksRequired > 0 {
+		cfg.IdleTicksRequired = o.idleTicksRequired
+	}
+
+	// Retry & backoff
+	if o.maxAttempts > 0 {
+		cfg.MaxAttempts = o.maxAttempts
+	}
+	if o.backoffAlgorithm != 0 {
+		cfg.BackoffAlgorithm = o.backoffAlgorithm
+	}
+	if o.backoffBaseDelay > 0 {
+		cfg.BackoffBaseDelay = o.backoffBaseDelay
+	}
+	if o.backoffMaxDelay > 0 {
+		cfg.BackoffMaxDelay = o.backoffMaxDelay
+	}
+	if o.backoffMaxExponent > 0 {
+		cfg.BackoffMaxExponent = o.backoffMaxExponent
+	}
+	if o.backoffFixedInterval > 0 {
+		cfg.BackoffFixedInterval = o.backoffFixedInterval
+	}
+	if o.backoffFixedMaxAttempts > 0 {
+		cfg.BackoffFixedMaxAttempts = o.backoffFixedMaxAttempts
+	}
+
+	// Circuit breaker
+	if o.circuitBreakerThreshold > 0 {
+		cfg.CircuitBreakerThreshold = o.circuitBreakerThreshold
+	}
+	if o.circuitBreakerResetAfter > 0 {
+		cfg.CircuitBreakerResetAfter = o.circuitBreakerResetAfter
+	}
+
+	// Producer
+	if o.producerPipelines > 0 {
+		cfg.ProducerPipelines = o.producerPipelines
+	}
+	if o.batchMaxSize > 0 {
+		cfg.BatchMaxSize = o.batchMaxSize
+	}
+	if o.batchMaxDelay > 0 {
+		cfg.BatchMaxDelay = o.batchMaxDelay
+	}
+
+	// Server side buffering
+	if o.heartbeatInterval > 0 {
+		cfg.HeartbeatInterval = o.heartbeatInterval
+	}
+	if o.outputBufferSize != 0 {
+		cfg.OutputBufferSize = o.outputBufferSize
+	}
+	if o.outputBufferTimeout != 0 {
+		cfg.OutputBufferTimeout = o.outputBufferTimeout
+	}
+
+	// Compression
+	if o.compression != 0 {
+		cfg.Compression = o.compression
+	}
+	if o.deflateLevel > 0 {
+		cfg.DeflateLevel = o.deflateLevel
+	}
+
+	// Zero copy / ACK batching / adaptive buffer
+	if o.zeroCopyThreshold > 0 {
+		cfg.ZeroCopyThreshold = o.zeroCopyThreshold
+	}
+	if o.ackBatchSize > 0 {
+		cfg.AckBatchSize = o.ackBatchSize
+	}
+	if o.ackBatchDelay > 0 {
+		cfg.AckBatchDelay = o.ackBatchDelay
+	}
+	if o.adaptiveBufferEnabled != nil {
+		cfg.AdaptiveBufferEnabled = *o.adaptiveBufferEnabled
+	}
+	if o.adaptiveBufferInitial > 0 {
+		cfg.AdaptiveBufferInitial = o.adaptiveBufferInitial
+	}
+	if o.adaptiveBufferMax > 0 {
+		cfg.AdaptiveBufferMax = o.adaptiveBufferMax
+	}
+
+	// Identity
+	if o.clientID != "" {
+		cfg.ClientID = o.clientID
+	}
+	if o.hostname != "" {
+		cfg.Hostname = o.hostname
+	}
+	if o.userAgent != "" {
+		cfg.UserAgent = o.userAgent
+	}
+
+	// Metrics
+	if o.metricsBackend != 0 {
+		cfg.MetricsBackend = o.metricsBackend
+	}
+	if o.statsdAddr != "" {
+		cfg.StatsdAddr = o.statsdAddr
+	}
+	if o.statsdPrefix != "" {
+		cfg.StatsdPrefix = o.statsdPrefix
+	}
+	if o.prometheusNamespace != "" {
+		cfg.PrometheusNamespace = o.prometheusNamespace
+	}
+	if o.metricsFlushInterval > 0 {
+		cfg.MetricsFlushInterval = o.metricsFlushInterval
+	}
+
+	// TLS
+	if o.tlsConfig != nil {
+		cfg.TLSConfig = o.tlsConfig
+	}
+
+	return cfg
+}
+
+// Existing options (backward compatible previous offical go-nsq)
 
 func MaxInFlight(m int) func(*options) {
-	return func(o *options) {
-		o.maxInFlight = m
-	}
+	return func(o *options) { o.maxInFlight = m }
 }
 
 func Channel(c string) func(*options) {
-	return func(o *options) {
-		o.channel = c
-	}
+	return func(o *options) { o.channel = c }
 }
 
-// Concurrency sets concurrency for the consumer.
 func Concurrency(c int) func(*options) {
-	return func(o *options) {
-		o.concurrency = c
-	}
+	return func(o *options) { o.concurrency = c }
 }
 
-// Ordered sets concurrency to 1 to preserve order
-// of incomming messages while calling handler.
 func Ordered() func(*options) {
-	return func(o *options) {
-		o.concurrency = 1
-	}
+	return func(o *options) { o.concurrency = 1 }
 }
 
-// LogLevelDebug sets log level to Debug for underlying go-nsq package.
 func LogLevelDebug() func(*options) {
+	return func(o *options) { o.logLevel = nsqx.LogLevelDebug }
+}
+
+// New options
+
+// Timeouts
+func DialTimeout(d time.Duration) func(*options) {
+	return func(o *options) { o.dialTimeout = d }
+}
+func ReadTimeout(d time.Duration) func(*options) {
+	return func(o *options) { o.readTimeout = d }
+}
+func WriteTimeout(d time.Duration) func(*options) {
+	return func(o *options) { o.writeTimeout = d }
+}
+
+// Discovery
+func LookupdPollInterval(d time.Duration) func(*options) {
+	return func(o *options) { o.lookupdPollInterval = d }
+}
+func LookupdPollJitter(f float64) func(*options) {
+	return func(o *options) { o.lookupdPollJitter = f }
+}
+func LookupdCacheTTL(d time.Duration) func(*options) {
+	return func(o *options) { o.lookupdCacheTTL = d }
+}
+func LookupdPollTimeout(d time.Duration) func(*options) {
+	return func(o *options) { o.lookupdPollTimeout = d }
+}
+
+// Adaptive RDY
+func RDYEvalInterval(d time.Duration) func(*options) {
+	return func(o *options) { o.rdyEvalInterval = d }
+}
+func RDYSlowStartInitial(n int64) func(*options) {
+	return func(o *options) { o.rdySlowStartInitial = n }
+}
+func RDYSlowStartInterval(d time.Duration) func(*options) {
+	return func(o *options) { o.rdySlowStartInterval = d }
+}
+func IdleConnectionRDY(n int64) func(*options) {
+	return func(o *options) { o.idleConnectionRDY = n }
+}
+func EMAAlpha(f float64) func(*options) {
+	return func(o *options) { o.emaAlpha = f }
+}
+func IdleRateThreshold(f float64) func(*options) {
+	return func(o *options) { o.idleRateThreshold = f }
+}
+func IdleTicksRequired(n int) func(*options) {
+	return func(o *options) { o.idleTicksRequired = n }
+}
+
+// Retry & backoff
+func MaxAttempts(n uint16) func(*options) {
+	return func(o *options) { o.maxAttempts = n }
+}
+func BackoffAlgorithm(a nsqx.BackoffAlgo) func(*options) {
+	return func(o *options) { o.backoffAlgorithm = a }
+}
+func BackoffBaseDelay(d time.Duration) func(*options) {
+	return func(o *options) { o.backoffBaseDelay = d }
+}
+func BackoffMaxDelay(d time.Duration) func(*options) {
+	return func(o *options) { o.backoffMaxDelay = d }
+}
+func BackoffMaxExponent(n uint) func(*options) {
+	return func(o *options) { o.backoffMaxExponent = n }
+}
+func BackoffFixedInterval(d time.Duration) func(*options) {
+	return func(o *options) { o.backoffFixedInterval = d }
+}
+func BackoffFixedMaxAttempts(n int) func(*options) {
+	return func(o *options) { o.backoffFixedMaxAttempts = n }
+}
+
+// Circuit breaker
+func CircuitBreakerThreshold(n int32) func(*options) {
+	return func(o *options) { o.circuitBreakerThreshold = n }
+}
+func CircuitBreakerResetAfter(d time.Duration) func(*options) {
+	return func(o *options) { o.circuitBreakerResetAfter = d }
+}
+
+// Producer
+func ProducerPipelines(n int) func(*options) {
+	return func(o *options) { o.producerPipelines = n }
+}
+func BatchMaxSize(n int) func(*options) {
+	return func(o *options) { o.batchMaxSize = n }
+}
+func BatchMaxDelay(d time.Duration) func(*options) {
+	return func(o *options) { o.batchMaxDelay = d }
+}
+
+// Server side buffering
+func HeartbeatInterval(d time.Duration) func(*options) {
+	return func(o *options) { o.heartbeatInterval = d }
+}
+func OutputBufferSize(n int) func(*options) {
+	return func(o *options) { o.outputBufferSize = n }
+}
+func OutputBufferTimeout(d time.Duration) func(*options) {
+	return func(o *options) { o.outputBufferTimeout = d }
+}
+
+// Compression
+func Compression(c nsqx.CompressionCodec) func(*options) {
+	return func(o *options) { o.compression = c }
+}
+func DeflateLevel(n int) func(*options) {
+	return func(o *options) { o.deflateLevel = n }
+}
+
+// Zero copy / ACK batching / adaptive buffer
+func ZeroCopyThreshold(n int) func(*options) {
+	return func(o *options) { o.zeroCopyThreshold = n }
+}
+func AckBatchSize(n int) func(*options) {
+	return func(o *options) { o.ackBatchSize = n }
+}
+func AckBatchDelay(d time.Duration) func(*options) {
+	return func(o *options) { o.ackBatchDelay = d }
+}
+func AdaptiveBufferEnabled(b bool) func(*options) {
+	return func(o *options) { o.adaptiveBufferEnabled = &b }
+}
+func AdaptiveBufferInitial(n int) func(*options) {
+	return func(o *options) { o.adaptiveBufferInitial = n }
+}
+func AdaptiveBufferMax(n int) func(*options) {
+	return func(o *options) { o.adaptiveBufferMax = n }
+}
+
+// Identity
+func ClientID(s string) func(*options) {
+	return func(o *options) { o.clientID = s }
+}
+func Hostname(s string) func(*options) {
+	return func(o *options) { o.hostname = s }
+}
+func UserAgent(s string) func(*options) {
+	return func(o *options) { o.userAgent = s }
+}
+
+// Metrics
+func MetricsPrometheus(namespace string) func(*options) {
 	return func(o *options) {
-		o.logLevel = gonsq.LogLevelDebug
+		o.metricsBackend = nsqx.MetricsPrometheus
+		o.prometheusNamespace = namespace
 	}
+}
+func MetricsStatsd(addr, prefix string) func(*options) {
+	return func(o *options) {
+		o.metricsBackend = nsqx.MetricsStatsd
+		o.statsdAddr = addr
+		o.statsdPrefix = prefix
+	}
+}
+func MetricsFlushInterval(d time.Duration) func(*options) {
+	return func(o *options) { o.metricsFlushInterval = d }
+}
+
+// TLS
+func TLSConfig(cfg *tls.Config) func(*options) {
+	return func(o *options) { o.tlsConfig = cfg }
 }

--- a/nsq/producer.go
+++ b/nsq/producer.go
@@ -3,12 +3,12 @@ package nsq
 import (
 	"github.com/minus5/svckit/log"
 
-	gonsq "github.com/nsqio/go-nsq"
+	nsqx "github.com/minus5/go-nsqx"
 )
 
 type Producer struct {
 	topic       string
-	nsqProducer *gonsq.Producer
+	nsqProducer *nsqx.Producer
 }
 
 func MustNewProducer(topic string, opts ...func(*options)) *Producer {
@@ -23,8 +23,8 @@ func NewProducer(topic string, opts ...func(*options)) (*Producer, error) {
 	o := getDefaults().clone()
 	o.apply(opts...)
 
-	cfg := gonsq.NewConfig()
-	p, err := gonsq.NewProducer(o.nsqdTCPAddr, cfg)
+	cfg := o.toNsqxConfig()
+	p, err := nsqx.NewProducer(o.nsqdTCPAddr, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/nsq/rr_producer.go
+++ b/nsq/rr_producer.go
@@ -71,7 +71,7 @@ func defaultErrorParser(s string) error {
 	if s == "" {
 		return nil
 	}
-	return errors.New(s)
+	return fmt.Errorf(s)
 }
 
 // RrProducerConsumerOptions sets configuration options for the underlying Consumer of RrProducer.


### PR DESCRIPTION
- backward compatibile - used same function names and methods, where I could.

- options.go - add new go-nsqx fields, toNsqxConfig() method
- nsq.go - added *nsqx.Discovery via getDiscovery, logger the same
- consumer.go - gonsq.Consumer->nsqx.Consumer, used SetDiscovery for lookupds, Close() simplified -> go-nsqx Stop() blocks until drained StartClosing() returns closed chan int
- producer.go - swap gonsq.NewProducer -> nsqx.NewProducer, change to use new config
- message.go - simple swap for gonsq to nsqx

Files left the same:
envelope.go, rpc.go, rr_consumer.go, rr_producer.go - wrap nsq svckit wrapper, so no changes